### PR TITLE
FI-1407: Refresh tokens

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,4 @@ gem 'us_core_test_kit',
     branch: 'main'
 gem 'smart_app_launch_test_kit',
     git: 'https://github.com/inferno-framework/smart-app-launch-test-kit.git',
-    branch: 'fi-1407-refresh-tokens'
+    branch: 'main'

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,4 @@ gem 'us_core_test_kit',
     branch: 'main'
 gem 'smart_app_launch_test_kit',
     git: 'https://github.com/inferno-framework/smart-app-launch-test-kit.git',
-    branch: 'main'
+    branch: 'fi-1407-refresh-tokens'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/inferno-framework/smart-app-launch-test-kit.git
-  revision: 4ba8db2ccd1e517b92da0693641459f13a37d6d8
-  branch: main
+  revision: 898c250e911e895e3e621af9c38ac8d006a00029
+  branch: fi-1407-refresh-tokens
   specs:
     smart_app_launch_test_kit (0.0.1)
       inferno_core (~> 0.1.0)
@@ -250,7 +250,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.3)
-    rubocop (1.25.0)
+    rubocop (1.25.1)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,21 @@
 GIT
   remote: https://github.com/inferno-framework/smart-app-launch-test-kit.git
-  revision: 898c250e911e895e3e621af9c38ac8d006a00029
-  branch: fi-1407-refresh-tokens
+  revision: 9bece50196d0021a755f944002c60999ef5c910c
+  branch: main
   specs:
     smart_app_launch_test_kit (0.0.1)
       inferno_core (~> 0.1.0)
       jwt (~> 2.2)
+      tls_test_kit (~> 0.0.1)
 
 GIT
   remote: https://github.com/inferno-framework/us-core-test-kit.git
-  revision: b7fa4581b07f7357a835cca7c62bc317e4a39ea8
+  revision: 2c6da84e62a536334d0876402ac1f536fbaebfc6
   branch: main
   specs:
     us_core_test_kit (0.0.1)
       inferno_core (~> 0.1.1)
+      tls_test_kit (~> 0.0.1)
 
 PATH
   remote: .
@@ -216,12 +218,12 @@ GEM
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
-    pry (0.14.1)
+    pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.8.0)
+    pry-byebug (3.9.0)
       byebug (~> 11.0)
-      pry (~> 0.10)
+      pry (~> 0.13.0)
     public_suffix (4.0.6)
     puma (5.6.1)
       nio4r (~> 2.0)
@@ -274,6 +276,8 @@ GEM
     sqlite3 (1.4.2)
     thor (1.1.0)
     tilt (2.0.10)
+    tls_test_kit (0.0.1)
+      inferno_core (~> 0.1.2)
     transproc (1.1.1)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)

--- a/lib/g10_certification_test_kit.rb
+++ b/lib/g10_certification_test_kit.rb
@@ -144,3 +144,28 @@ module G10CertificationTestKit
     end
   end
 end
+
+# TODO: address this input issue in core
+Inferno::Repositories::Tests.new
+  .find('g10_certification-g10_smart_limited_app-smart_standalone_launch-standalone_auth_tls')
+  .config(
+    inputs: {
+      url: {
+        title: 'Standalone Authorization URL',
+        description: '',
+        default: ''
+      }
+    }
+  )
+
+Inferno::Repositories::Tests.new
+  .find('g10_certification-g10_smart_limited_app-smart_standalone_launch-standalone_token_tls')
+  .config(
+    inputs: {
+      url: {
+        title: 'Standalone Token URL',
+        description: '',
+        default: ''
+      }
+    }
+  )

--- a/lib/g10_certification_test_kit/patient_context_test.rb
+++ b/lib/g10_certification_test_kit/patient_context_test.rb
@@ -6,15 +6,16 @@ module G10CertificationTestKit
       the app was launched in the context of this FHIR Patient.
     )
     id :g10_patient_context
-    input :patient_id, :access_token, :url
+    input :patient_id, :url
+    input :smart_credentials, type: :oauth_credentials
 
     fhir_client :authenticated do
       url :url
-      bearer_token :access_token
+      oauth_credentials :smart_credentials
     end
 
     run do
-      skip_if access_token.blank?, 'No access token was received during the SMART launch'
+      skip_if smart_credentials.access_token.blank?, 'No access token was received during the SMART launch'
 
       skip_if patient_id.blank?, 'Token response did not contain `patient` field'
 

--- a/lib/g10_certification_test_kit/restricted_resource_type_access_group.rb
+++ b/lib/g10_certification_test_kit/restricted_resource_type_access_group.rb
@@ -50,7 +50,8 @@ module G10CertificationTestKit
     )
     id :g10_restricted_resource_type_access
 
-    input :url, :access_token, :patient_id, :received_scopes, :expected_resources
+    input :url, :patient_id, :received_scopes, :expected_resources
+    input :smart_credentials, type: :oauth_credentials
 
     config(
       inputs: {
@@ -66,7 +67,7 @@ module G10CertificationTestKit
 
     fhir_client do
       url :url
-      bearer_token :access_token
+      oauth_credentials :smart_credentials
     end
 
     test from: :g10_restricted_access_test do

--- a/lib/g10_certification_test_kit/smart_ehr_practitioner_app_group.rb
+++ b/lib/g10_certification_test_kit/smart_ehr_practitioner_app_group.rb
@@ -28,6 +28,9 @@ module G10CertificationTestKit
         client_secret: {
           optional: false,
           default: 'SAMPLE_CONFIDENTIAL_CLIENT_SECRET'
+        },
+        smart_credentials: {
+          name: :ehr_smart_credentials
         }
       }
     )
@@ -142,7 +145,7 @@ module G10CertificationTestKit
               id_token: { name: :ehr_id_token },
               client_id: { name: :ehr_client_id },
               requested_scopes: { name: :ehr_requested_scopes },
-              access_token: { name: :ehr_access_token }
+              smart_credentials: { name: :ehr_smart_credentials }
             }
           }
 
@@ -161,21 +164,33 @@ module G10CertificationTestKit
           received_scopes: { name: :ehr_received_scopes },
           access_token: { name: :ehr_access_token },
           token_retrieval_time: { name: :ehr_token_retrieval_time },
-          expires_in: { name: :ehr_expires_in }
+          expires_in: { name: :ehr_expires_in },
+          smart_credentials: { name: :ehr_smart_credentials }
         }
       )
 
       test from: :g10_patient_context do
         config(
           inputs: {
-            patient_id: { name: :ehr_patient_id },
-            access_token: { name: :ehr_access_token }
+            patient_id: { name: :ehr_patient_id }
           },
           options: {
             refresh_test: true
           }
         )
         uses_request :token_refresh
+      end
+    end
+
+    test do
+      id :g10_ehr_credentials_export
+      title 'Set SMART Credentials to EHR Launch Credentials'
+
+      input :ehr_smart_credentials, type: :oauth_credentials
+      output :smart_credentials
+
+      run do
+        output smart_credentials: ehr_smart_credentials.to_s
       end
     end
   end

--- a/lib/g10_certification_test_kit/smart_limited_app_group.rb
+++ b/lib/g10_certification_test_kit/smart_limited_app_group.rb
@@ -42,36 +42,40 @@ module G10CertificationTestKit
           Sequence](http://hl7.org/fhir/smart-app-launch/#standalone-launch-sequence)
       )
 
-      config inputs: {
-        client_id: { locked: true },
-        client_secret: { locked: true },
-        url: { locked: true },
-        code: { name: :limited_code },
-        state: { name: :limited_state },
-        patient_id: { name: :limited_patient_id },
-        access_token: { name: :limited_access_token },
-        requested_scopes: { name: :limited_requested_scopes },
-        smart_authorization_url: { locked: true }, # TODO: separate standalone/ehr discovery outputs
-        smart_token_url: { locked: true }, # TODO: separate standalone/ehr discovery outputs
-        received_scopes: { name: :limited_received_scopes }
-      },
-             outputs: {
-               code: { name: :limited_code },
-               token_retrieval_time: { name: :limited_token_retrieval_time },
-               state: { name: :limited_state },
-               id_token: { name: :limited_id_token },
-               refresh_token: { name: :limited_refresh_token },
-               access_token: { name: :limited_access_token },
-               expires_in: { name: :limited_expires_in },
-               patient_id: { name: :limited_patient_id },
-               encounter_id: { name: :limited_encounter_id },
-               received_scopes: { name: :limited_received_scopes },
-               intent: { name: :limited_intent }
-             },
-             requests: {
-               redirect: { name: :limited_redirect },
-               token: { name: :limited_token }
-             }
+      config(
+        inputs: {
+          client_id: { locked: true },
+          client_secret: { locked: true },
+          url: { locked: true },
+          code: { name: :limited_code },
+          state: { name: :limited_state },
+          patient_id: { name: :limited_patient_id },
+          access_token: { name: :limited_access_token },
+          requested_scopes: { name: :limited_requested_scopes },
+          smart_authorization_url: { locked: true }, # TODO: separate standalone/ehr discovery outputs
+          smart_token_url: { locked: true }, # TODO: separate standalone/ehr discovery outputs
+          received_scopes: { name: :limited_received_scopes },
+          smart_credentials: { name: :limited_smart_credentials }
+        },
+        outputs: {
+          code: { name: :limited_code },
+          token_retrieval_time: { name: :limited_token_retrieval_time },
+          state: { name: :limited_state },
+          id_token: { name: :limited_id_token },
+          refresh_token: { name: :limited_refresh_token },
+          access_token: { name: :limited_access_token },
+          expires_in: { name: :limited_expires_in },
+          patient_id: { name: :limited_patient_id },
+          encounter_id: { name: :limited_encounter_id },
+          received_scopes: { name: :limited_received_scopes },
+          intent: { name: :limited_intent },
+          smart_credentials: { name: :limited_smart_credentials }
+        },
+        requests: {
+          redirect: { name: :limited_redirect },
+          token: { name: :limited_token }
+        }
+      )
 
       input :expected_resources,
             title: 'Expected Resource Grant',
@@ -82,7 +86,7 @@ module G10CertificationTestKit
            config: {
              inputs: {
                patient_id: { name: :limited_patient_id },
-               access_token: { name: :limited_access_token }
+               smart_credentials: { name: :limited_smart_credentials }
              }
            }
 
@@ -100,9 +104,9 @@ module G10CertificationTestKit
           config: {
             inputs: {
               patient_id: { name: :limited_patient_id },
-              access_token: { name: :limited_access_token },
               requested_scopes: { name: :limited_requested_scopes },
-              received_scopes: { name: :limited_received_scopes }
+              received_scopes: { name: :limited_received_scopes },
+              smart_credentials: { name: :limited_smart_credentials }
             }
           }
   end

--- a/lib/g10_certification_test_kit/smart_public_standalone_launch_group.rb
+++ b/lib/g10_certification_test_kit/smart_public_standalone_launch_group.rb
@@ -59,6 +59,9 @@ module G10CertificationTestKit
         smart_token_url: {
           title: 'OAuth 2.0 Token Endpoint',
           description: 'OAuth 2.0 Token Endpoint provided during the patient standalone launch'
+        },
+        smart_credentials: {
+          name: :public_smart_credentials
         }
       },
       outputs: {
@@ -72,7 +75,8 @@ module G10CertificationTestKit
         patient_id: { name: :public_patient_id },
         encounter_id: { name: :public_encounter_id },
         received_scopes: { name: :public_received_scopes },
-        intent: { name: :public_intent }
+        intent: { name: :public_intent },
+        smart_credentials: { name: :public_smart_credentials }
       },
       requests: {
         redirect: { name: :public_redirect },
@@ -84,7 +88,7 @@ module G10CertificationTestKit
          config: {
            inputs: {
              patient_id: { name: :public_patient_id },
-             access_token: { name: :public_access_token }
+             smart_credentials: { name: :public_smart_credentials }
            }
          }
 

--- a/lib/g10_certification_test_kit/smart_standalone_patient_app_group.rb
+++ b/lib/g10_certification_test_kit/smart_standalone_patient_app_group.rb
@@ -95,7 +95,7 @@ module G10CertificationTestKit
            config: {
              inputs: {
                patient_id: { name: :standalone_patient_id },
-               access_token: { name: :standalone_access_token }
+               smart_credentials: { name: :standalone_smart_credentials }
              }
            }
     end
@@ -106,7 +106,7 @@ module G10CertificationTestKit
               id_token: { name: :standalone_id_token },
               client_id: { name: :standalone_client_id },
               requested_scopes: { name: :standalone_requested_scopes },
-              access_token: { name: :standalone_access_token }
+              smart_credentials: { name: :standalone_smart_credentials }
             }
           }
 
@@ -125,7 +125,8 @@ module G10CertificationTestKit
           received_scopes: { name: :standalone_received_scopes },
           access_token: { name: :standalone_access_token },
           token_retrieval_time: { name: :standalone_token_retrieval_time },
-          expires_in: { name: :standalone_expires_in }
+          expires_in: { name: :standalone_expires_in },
+          smart_credentials: { name: :standalone_smart_credentials }
         }
       )
 
@@ -133,7 +134,7 @@ module G10CertificationTestKit
         config(
           inputs: {
             patient_id: { name: :standalone_patient_id },
-            access_token: { name: :standalone_access_token }
+            smart_credentials: { name: :standalone_smart_credentials }
           },
           options: {
             refresh_test: true
@@ -146,10 +147,22 @@ module G10CertificationTestKit
     group from: :g10_unrestricted_resource_type_access,
           config: {
             inputs: {
-              access_token: { name: :standalone_access_token },
               received_scopes: { name: :standalone_received_scopes },
-              patient_id: { name: :standalone_patient_id }
+              patient_id: { name: :standalone_patient_id },
+              smart_credentials: { name: :standalone_smart_credentials }
             }
           }
+
+    test do
+      id :g10_standalone_credentials_export
+      title 'Set SMART Credentials to Standalone Launch Credentials'
+
+      input :standalone_smart_credentials, type: :oauth_credentials
+      output :smart_credentials
+
+      run do
+        output smart_credentials: standalone_smart_credentials.to_s
+      end
+    end
   end
 end

--- a/lib/g10_certification_test_kit/unrestricted_resource_type_access_group.rb
+++ b/lib/g10_certification_test_kit/unrestricted_resource_type_access_group.rb
@@ -50,11 +50,12 @@ module G10CertificationTestKit
     )
     id :g10_unrestricted_resource_type_access
 
-    input :url, :access_token, :patient_id, :received_scopes
+    input :url, :smart_credentials, :patient_id, :received_scopes
+    input :smart_credentials, type: :oauth_credentials
 
     fhir_client do
       url :url
-      bearer_token :access_token
+      oauth_credentials :smart_credentials
     end
 
     test do

--- a/spec/g10_certification_test_kit/patient_context_test_spec.rb
+++ b/spec/g10_certification_test_kit/patient_context_test_spec.rb
@@ -16,16 +16,27 @@ RSpec.describe G10CertificationTestKit::PatientContextTest do
   let(:test) { described_class }
   let(:test_session) { repo_create(:test_session, test_suite_id: 'g10_certification') }
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:smart_credentials) do
+    {
+      access_token: 'ACCESS_TOKEN',
+      refresh_token: 'REFRESH_TOKEN',
+      expires_in: 3600,
+      client_id: 'CLIENT_ID',
+      token_retrieval_time: Time.now.iso8601,
+      token_url: 'http://example.com/token'
+    }.to_json
+  end
   let(:default_inputs) do
     {
       url: 'http://example.com/fhir',
       patient_id: '123',
-      access_token: 'ACCESS_TOKEN'
+      smart_credentials: smart_credentials
     }
   end
 
   it 'skips if the access token is blank' do
-    inputs = default_inputs.merge(access_token: '')
+    credentials = Inferno::DSL::OAuthCredentials.new(JSON.parse(smart_credentials).merge('access_token' => ''))
+    inputs = default_inputs.merge(smart_credentials: credentials.to_s)
     result = run(test, inputs)
 
     expect(result.result).to eq('skip')

--- a/spec/g10_certification_test_kit/resource_access_test_spec.rb
+++ b/spec/g10_certification_test_kit/resource_access_test_spec.rb
@@ -19,12 +19,14 @@ RSpec.describe G10CertificationTestKit::ResourceAccessTest do
     Class.new(G10CertificationTestKit::ResourceAccessTest) do
       fhir_client do
         url 'http://example.com/fhir'
-        bearer_token 'ACCESS_TOKEN'
+        oauth_credentials :smart_credentials
       end
 
       def resource_group
         USCore::AllergyIntoleranceGroup
       end
+
+      input :smart_credentials, type: :oauth_credentials
     end
   end
 
@@ -32,11 +34,21 @@ RSpec.describe G10CertificationTestKit::ResourceAccessTest do
   let(:session_data_repo) { Inferno::Repositories::SessionData.new }
   let(:url) { 'http://example.com/fhir' }
   let(:patient_id) { '123' }
+  let(:smart_credentials) do
+    {
+      access_token: 'ACCESS_TOKEN',
+      refresh_token: 'REFRESH_TOKEN',
+      expires_in: 3600,
+      client_id: 'CLIENT_ID',
+      token_retrieval_time: Time.now.iso8601,
+      token_url: 'http://example.com/token'
+    }.to_json
+  end
   let(:base_inputs) do
     {
       url: url,
       patient_id: patient_id,
-      access_token: 'ACCESS_TOKEN'
+      smart_credentials: smart_credentials
     }
   end
 


### PR DESCRIPTION
This branch updates the tests to use `oauth_credentials` so that they can automatically refresh access tokens.